### PR TITLE
Switch *real/run to py3 to avoid encoding issues

### DIFF
--- a/m01real/run
+++ b/m01real/run
@@ -1,6 +1,6 @@
-#!/usr/bin/python2
+#!/usr/bin/python3
 
-# A modifier : 
+# A modifier :
 # La liste expectedFiles, mettre les fichiers attendus dans l'archive zip.
 
 from os import listdir, system
@@ -26,21 +26,20 @@ unzipOutput = inginiousUtils.extract_zip_content('basicSubmission.zip', expected
 if (unzipOutput):
     output += unzipOutput
     output += "\n**Archive Content: 0/1**"
-    system('archive -a build.manifest')
     system('feedback --result failed --feedback "' + output + '"')
     exit(0)
 else:
     outjavac = ""
     try:
-    	outjavac = subprocess.check_output("javac student/*.java", stderr = subprocess.STDOUT, shell = True)
-    	output += "Your archive has the correct content.\n"
-    	output += "\n**Archive content: 1/1**"
-    	system('feedback --result success --feedback "' + output + '"')
-    except subprocess.CalledProcessError, e:
+        outjavac = subprocess.check_output("javac student/*.java", stderr = subprocess.STDOUT, shell = True)
+        output += "Your archive has the correct content.\n"
+        output += "\n**Archive content: 1/1**"
+        system('feedback --result success --feedback "' + output + '"')
+    except subprocess.CalledProcessError as e:
         output += "There are some compilation errors with your program :\n::\n\n"
         system("echo \""+e.output+"\" > outjavac.log")
-    	output += subprocess.check_output("sed -e \'s/^/\\t/\' < outjavac.log", shell = True)
-    	system('feedback --result failed --feedback "' + output + '"')
-     
-    
+        output += subprocess.check_output("sed -e \'s/^/\\t/\' < outjavac.log", shell = True)
+        system('feedback --result failed --feedback "' + output + '"')
+
+
     exit(0)

--- a/m03real1/run
+++ b/m03real1/run
@@ -1,4 +1,4 @@
-#!/usr/bin/python2
+#!/usr/bin/python3
 # -*- coding: utf-8 -*-
 from os import listdir, system
 import zipfile 
@@ -44,37 +44,36 @@ unzipOutput = inginiousUtils.extract_zip_content('basicSubmission.zip', expected
 if (unzipOutput):
     output += unzipOutput
     output += "\n**Archive Content: 0/1**"
-    system('archive -a build.manifest')
     system('feedback --result failed --feedback "' + output + '"')
     exit(0)
 else:
     system('sh custom.sh')
     try:
-    	subprocess.check_output("javac -cp .:/usr/share/java/junit.jar:/usr/share/java/hamcrest-core.jar student/*.java", stderr = subprocess.STDOUT, shell = True)
-    	output += "Your archive has the correct content.\n"
-    	output += "\n**Archive content: 1/1**"
-    	system('feedback --result success --feedback "' + output + '"')
-    except subprocess.CalledProcessError, e:
+        subprocess.check_output("javac -cp .:/usr/share/java/junit.jar:/usr/share/java/hamcrest-core.jar student/*.java", stderr = subprocess.STDOUT, shell = True)
+        output += "Your archive has the correct content.\n"
+        output += "\n**Archive content: 1/1**"
+        system('feedback --result success --feedback "' + output + '"')
+    except subprocess.CalledProcessError as e:
         output += "There are some compilation errors with your program :\n::\n\n"
         #system("echo \""+e.output+"\" > outjavac.log")
         sp = subprocess.Popen(["sed", "-e", "s/^/\\t/"], stdin=subprocess.PIPE, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
-    	output += sp.communicate(e.output)[0]
-    	sp = subprocess.Popen(["feedback", "--result", "failed", "--feedback", output])
-    	exit(1)
+        output += sp.communicate(e.output)[0]
+        sp = subprocess.Popen(["feedback", "--result", "failed", "--feedback", output])
+        exit(1)
     # On lance le feedback complet
     system('sh run.sh')
     if (os.stat("feedback.out").st_size != 0):
-    	output += "\n\n.. hidden-until:: \"" + deadline + "\"\n\n"
-    	system('echo "' + output + '" > feed1')
-    	system('sed -e \'s/^/\\t/\' < feedback.out > feedback2.out')
-    	output2 = subprocess.check_output("cat feed1 feedback2.out", shell = True)
-    	system("feedback -i q1 --result success --feedback \"" + output2 + "\"")
-    	system("feedback --result success --feedback \" \" ")
+        output += "\n\n.. hidden-until:: \"" + deadline + "\"\n\n"
+        system('echo "' + output + '" > feed1')
+        system('sed -e \'s/^/\\t/\' < feedback.out > feedback2.out')
+        output2 = subprocess.check_output("cat feed1 feedback2.out", shell = True)
+        system("feedback -i q1 --result success --feedback \"" + output2 + "\"")
+        system("feedback --result success --feedback \" \" ")
     else:
         output += "\n\n.. hidden-until:: \"" + deadline + "\"\n\n"
-    	system('echo "' + output + '" > feed1')
+        system('echo "' + output + '" > feed1')
         system('echo "Bravo, les tests se sont bien passés !" > feedback.out')
-    	system('sed -e \'s/^/\\t/\' < feedback.out > feedback2.out')
-    	output2 = subprocess.check_output("cat feed1 feedback2.out", shell = True)
+        system('sed -e \'s/^/\\t/\' < feedback.out > feedback2.out')
+        output2 = subprocess.check_output("cat feed1 feedback2.out", shell = True)
         system("feedback -i q1 --result success --feedback \"" + output2 + "\"")
-    	system("feedback --result success --feedback \" \" ")
+        system("feedback --result success --feedback \" \" ")

--- a/m04real/run
+++ b/m04real/run
@@ -1,4 +1,4 @@
-#!/usr/bin/python2
+#!/usr/bin/python3
 # -*- coding: utf-8 -*-
 
 # A modifier : 
@@ -43,26 +43,25 @@ unzipOutput = inginiousUtils.extract_zip_content('basicSubmission.zip', expected
 if (unzipOutput):
     output += unzipOutput
     output += "\n**Archive Content: 0/1**"
-    system('archive -a build.manifest')
     system('feedback --result failed --feedback "' + output + '"')
     exit(0)
 else:
     system('sh custom.sh')
     try:
-    	subprocess.check_output("javac -cp .:/usr/share/java/junit.jar:/usr/share/java/hamcrest-core.jar student/*.java", stderr = subprocess.STDOUT, shell = True)
-    	output += "Your archive has the correct content.\n"
-    	output += "\n**Archive content: 1/1**"
-    	system('feedback --result success --feedback "' + output + '"')
-    except subprocess.CalledProcessError, e:
+        subprocess.check_output("javac -cp .:/usr/share/java/junit.jar:/usr/share/java/hamcrest-core.jar student/*.java", stderr = subprocess.STDOUT, shell = True)
+        output += "Your archive has the correct content.\n"
+        output += "\n**Archive content: 1/1**"
+        system('feedback --result success --feedback "' + output + '"')
+    except subprocess.CalledProcessError as e:
         output += "There are some compilation errors with your program :\n::\n\n"
         sp = subprocess.Popen(["sed", "-e", "s/^/\\t/"], stdin=subprocess.PIPE, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
-    	output += sp.communicate(e.output)[0]
-    	sp = subprocess.Popen(["feedback", "--result", "failed", "--feedback", output])
-    	exit(1)
+        output += sp.communicate(e.output)[0]
+        sp = subprocess.Popen(["feedback", "--result", "failed", "--feedback", output])
+        exit(1)
     # On lance le feedback complet
     system('sh run.sh')
     if (os.stat("feedback.out").st_size != 0):
-    	output += "\n\n.. hidden-until:: " + deadline + "\n\n"
+        output += "\n\n.. hidden-until:: " + deadline + "\n\n"
         feed1 = open('feed1', 'w+')
         feed1.write(output)
         feedbackout = open('feedback.out', 'r')
@@ -87,9 +86,9 @@ else:
         proc.wait()
     else:
         output += "\n\n.. hidden-until:: \"" + deadline + "\"\n\n"
-    	system('echo "' + output + '" > feed1')
+        system('echo "' + output + '" > feed1')
         system('echo "Bravo, les tests se sont bien passés !" > feedback.out')
-    	system('sed -e \'s/^/\\t/\' < feedback.out > feedback2.out')
-    	output2 = subprocess.check_output("cat feed1 feedback2.out", shell = True)
+        system('sed -e \'s/^/\\t/\' < feedback.out > feedback2.out')
+        output2 = subprocess.check_output("cat feed1 feedback2.out", shell = True)
         system("feedback -i q1 --result success --feedback \"" + output2 + "\"")
-    	system("feedback --result success --feedback \" \" ")
+        system("feedback --result success --feedback \" \" ")

--- a/m05real/run
+++ b/m05real/run
@@ -1,4 +1,4 @@
-#!/usr/bin/python2
+#!/usr/bin/python3
 # -*- coding: utf-8 -*-
 
 # A modifier : 
@@ -44,26 +44,25 @@ unzipOutput = inginiousUtils.extract_zip_content('basicSubmission.zip', expected
 if (unzipOutput):
     output += unzipOutput
     output += "\n**Archive Content: 0/1**"
-    system('archive -a build.manifest')
     system('feedback --result failed --feedback "' + output + '"')
     exit(0)
 else:
     system('sh custom.sh')
     try:
-    	subprocess.check_output("javac -cp .:/usr/share/java/junit.jar:/usr/share/java/hamcrest-core.jar student/*.java", stderr = subprocess.STDOUT, shell = True)
-    	output += "Your archive has the correct content.\n"
-    	output += "\n**Archive content: 1/1**"
-    	system('feedback --result success --feedback "' + output + '"')
-    except subprocess.CalledProcessError, e:
+        subprocess.check_output("javac -cp .:/usr/share/java/junit.jar:/usr/share/java/hamcrest-core.jar student/*.java", stderr = subprocess.STDOUT, shell = True)
+        output += "Your archive has the correct content.\n"
+        output += "\n**Archive content: 1/1**"
+        system('feedback --result success --feedback "' + output + '"')
+    except subprocess.CalledProcessError as e:
         output += "There are some compilation errors with your program :\n::\n\n"
         sp = subprocess.Popen(["sed", "-e", "s/^/\\t/"], stdin=subprocess.PIPE, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
-    	output += sp.communicate(e.output)[0]
-    	sp = subprocess.Popen(["feedback", "--result", "failed", "--feedback", output])
-    	exit(1)
+        output += sp.communicate(e.output)[0]
+        sp = subprocess.Popen(["feedback", "--result", "failed", "--feedback", output])
+        exit(1)
     # On lance le feedback complet
     system('sh run.sh')
     if (os.stat("feedback.out").st_size != 0):
-    	output += "\n\n.. hidden-until:: " + deadline + "\n\n"
+        output += "\n\n.. hidden-until:: " + deadline + "\n\n"
         feed1 = open('feed1', 'w+')
         feed1.write(output)
         feedbackout = open('feedback.out', 'r')
@@ -88,9 +87,9 @@ else:
         proc.wait()
     else:
         output += "\n\n.. hidden-until:: \"" + deadline + "\"\n\n"
-    	system('echo "' + output + '" > feed1')
+        system('echo "' + output + '" > feed1')
         system('echo "Bravo, les tests se sont bien passés !" > feedback.out')
-    	system('sed -e \'s/^/\\t/\' < feedback.out > feedback2.out')
-    	output2 = subprocess.check_output("cat feed1 feedback2.out", shell = True)
+        system('sed -e \'s/^/\\t/\' < feedback.out > feedback2.out')
+        output2 = subprocess.check_output("cat feed1 feedback2.out", shell = True)
         system("feedback -i q1 --result success --feedback \"" + output2 + "\"")
-    	system("feedback --result success --feedback \" \" ")
+        system("feedback --result success --feedback \" \" ")

--- a/m06real/run
+++ b/m06real/run
@@ -1,4 +1,4 @@
-#!/usr/bin/python2
+#!/usr/bin/python3
 # -*- coding: utf-8 -*-
 
 # A modifier : 
@@ -41,26 +41,25 @@ unzipOutput = inginiousUtils.extract_zip_content('basicSubmission.zip', expected
 if (unzipOutput):
     output += unzipOutput
     output += "\n**Archive Content: 0/1**"
-    system('archive -a build.manifest')
     system('feedback --result failed --feedback "' + output + '"')
     exit(0)
 else:
     system('sh custom.sh')
     try:
-    	subprocess.check_output("javac -cp .:/usr/share/java/junit.jar:/usr/share/java/hamcrest-core.jar student/*.java", stderr = subprocess.STDOUT, shell = True)
-    	output += "Your archive has the correct content.\n"
-    	output += "\n**Archive content: 1/1**"
-    	system('feedback --result success --feedback "' + output + '"')
-    except subprocess.CalledProcessError, e:
+        subprocess.check_output("javac -cp .:/usr/share/java/junit.jar:/usr/share/java/hamcrest-core.jar student/*.java", stderr = subprocess.STDOUT, shell = True)
+        output += "Your archive has the correct content.\n"
+        output += "\n**Archive content: 1/1**"
+        system('feedback --result success --feedback "' + output + '"')
+    except subprocess.CalledProcessError as e:
         output += "There are some compilation errors with your program :\n::\n\n"
         sp = subprocess.Popen(["sed", "-e", "s/^/\\t/"], stdin=subprocess.PIPE, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
-    	output += sp.communicate(e.output)[0]
-    	sp = subprocess.Popen(["feedback", "--result", "failed", "--feedback", output])
-    	exit(1)
+        output += sp.communicate(e.output)[0]
+        sp = subprocess.Popen(["feedback", "--result", "failed", "--feedback", output])
+        exit(1)
     # On lance le feedback complet
     system('sh run.sh')
     if (os.stat("feedback.out").st_size != 0):
-    	output += "\n\n.. hidden-until:: " + deadline + "\n\n"
+        output += "\n\n.. hidden-until:: " + deadline + "\n\n"
         feed1 = open('feed1', 'w+')
         feed1.write(output)
         feedbackout = open('feedback.out', 'r')
@@ -85,9 +84,9 @@ else:
         proc.wait()
     else:
         output += "\n\n.. hidden-until:: \"" + deadline + "\"\n\n"
-    	system('echo "' + output + '" > feed1')
+        system('echo "' + output + '" > feed1')
         system('echo "Bravo, les tests se sont bien passés ! Faites cependant attention, les tests ne sont pas tout à fait complets étant donné que l\'on vous donne une certaine liberté sur l\'implémentation de la classe. Un feedback vert sur INGInious ne veut donc pas dire que tout est parfaitement correct." > feedback.out')
-    	system('sed -e \'s/^/\\t/\' < feedback.out > feedback2.out')
-    	output2 = subprocess.check_output("cat feed1 feedback2.out", shell = True)
+        system('sed -e \'s/^/\\t/\' < feedback.out > feedback2.out')
+        output2 = subprocess.check_output("cat feed1 feedback2.out", shell = True)
         system("feedback -i q1 --result success --feedback \"" + output2 + "\"")
-    	system("feedback --result success --feedback \" \" ")
+        system("feedback --result success --feedback \" \" ")

--- a/m07real/run
+++ b/m07real/run
@@ -1,4 +1,4 @@
-#!/usr/bin/python2
+#!/usr/bin/python3
 # -*- coding: utf-8 -*-
 
 # A modifier : 
@@ -42,26 +42,25 @@ unzipOutput = inginiousUtils.extract_zip_content('basicSubmission.zip', expected
 if (unzipOutput):
     output += unzipOutput
     output += "\n**Archive Content: 0/1**"
-    system('archive -a build.manifest')
     system('feedback --result failed --feedback "' + output + '"')
     exit(0)
 else:
     system('sh custom.sh')
     try:
-    	subprocess.check_output("javac -cp .:/usr/share/java/junit.jar:/usr/share/java/hamcrest-core.jar student/*.java", stderr = subprocess.STDOUT, shell = True)
-    	output += "Your archive has the correct content.\n"
-    	output += "\n**Archive content: 1/1**"
-    	system('feedback --result success --feedback "' + output + '"')
-    except subprocess.CalledProcessError, e:
+        subprocess.check_output("javac -cp .:/usr/share/java/junit.jar:/usr/share/java/hamcrest-core.jar student/*.java", stderr = subprocess.STDOUT, shell = True)
+        output += "Your archive has the correct content.\n"
+        output += "\n**Archive content: 1/1**"
+        system('feedback --result success --feedback "' + output + '"')
+    except subprocess.CalledProcessError as e:
         output += "There are some compilation errors with your program :\n::\n\n"
         sp = subprocess.Popen(["sed", "-e", "s/^/\\t/"], stdin=subprocess.PIPE, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
-    	output += sp.communicate(e.output)[0]
-    	sp = subprocess.Popen(["feedback", "--result", "failed", "--feedback", output])
-    	exit(1)
+        output += sp.communicate(e.output)[0]
+        sp = subprocess.Popen(["feedback", "--result", "failed", "--feedback", output])
+        exit(1)
     # On lance le feedback complet
     system('sh run.sh')
     if (os.stat("feedback.out").st_size != 0):
-    	output += "\n\n.. hidden-until:: " + deadline + "\n\n"
+        output += "\n\n.. hidden-until:: " + deadline + "\n\n"
         feed1 = open('feed1', 'w+')
         feed1.write(output)
         feedbackout = open('feedback.out', 'r')
@@ -86,9 +85,9 @@ else:
         proc.wait()
     else:
         output += "\n\n.. hidden-until:: \"" + deadline + "\"\n\n"
-    	system('echo "' + output + '" > feed1')
+        system('echo "' + output + '" > feed1')
         system('echo "Bravo, les tests se sont bien passés ! Faites cependant attention, les tests ne sont pas tout à fait complets étant donné que l\'on vous donne une certaine liberté sur l\'implémentation de la classe. Un feedback vert sur INGInious ne veut donc pas dire que tout est parfaitement correct." > feedback.out')
-    	system('sed -e \'s/^/\\t/\' < feedback.out > feedback2.out')
-    	output2 = subprocess.check_output("cat feed1 feedback2.out", shell = True)
+        system('sed -e \'s/^/\\t/\' < feedback.out > feedback2.out')
+        output2 = subprocess.check_output("cat feed1 feedback2.out", shell = True)
         system("feedback -i q1 --result success --feedback \"" + output2 + "\"")
-    	system("feedback --result success --feedback \" \" ")
+        system("feedback --result success --feedback \" \" ")

--- a/m08real/run
+++ b/m08real/run
@@ -1,4 +1,4 @@
-#!/usr/bin/python2
+#!/usr/bin/python3
 # -*- coding: utf-8 -*-
 
 # A modifier : 
@@ -41,26 +41,25 @@ unzipOutput = inginiousUtils.extract_zip_content('basicSubmission.zip', expected
 if (unzipOutput):
     output += unzipOutput
     output += "\n**Archive Content: 0/1**"
-    system('archive -a build.manifest')
     system('feedback --result failed --feedback "' + output + '"')
     exit(0)
 else:
     system('sh custom.sh')
     try:
-    	subprocess.check_output("javac -cp .:/usr/share/java/junit.jar:/usr/share/java/hamcrest-core.jar student/*.java", stderr = subprocess.STDOUT, shell = True)
-    	output += "Your archive has the correct content.\n"
-    	output += "\n**Archive content: 1/1**"
-    	system('feedback --result success --feedback "' + output + '"')
-    except subprocess.CalledProcessError, e:
+        subprocess.check_output("javac -cp .:/usr/share/java/junit.jar:/usr/share/java/hamcrest-core.jar student/*.java", stderr = subprocess.STDOUT, shell = True)
+        output += "Your archive has the correct content.\n"
+        output += "\n**Archive content: 1/1**"
+        system('feedback --result success --feedback "' + output + '"')
+    except subprocess.CalledProcessError as e:
         output += "There are some compilation errors with your program :\n::\n\n"
         sp = subprocess.Popen(["sed", "-e", "s/^/\\t/"], stdin=subprocess.PIPE, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
-    	output += sp.communicate(e.output)[0]
-    	sp = subprocess.Popen(["feedback", "--result", "failed", "--feedback", output])
-    	exit(1)
+        output += sp.communicate(e.output)[0]
+        sp = subprocess.Popen(["feedback", "--result", "failed", "--feedback", output])
+        exit(1)
     # On lance le feedback complet
     system('sh run.sh')
     if (os.stat("feedback.out").st_size != 0):
-    	output += "\n\n.. hidden-until:: " + deadline + "\n\n"
+        output += "\n\n.. hidden-until:: " + deadline + "\n\n"
         feed1 = open('feed1', 'w+')
         feed1.write(output)
         feedbackout = open('feedback.out', 'r')
@@ -85,9 +84,9 @@ else:
         proc.wait()
     else:
         output += "\n\n.. hidden-until:: \"" + deadline + "\"\n\n"
-    	system('echo "' + output + '" > feed1')
+        system('echo "' + output + '" > feed1')
         system('echo "Bravo, les tests se sont bien passés ! Faites cependant attention, les tests ne sont pas tout à fait complets étant donné que l\'on vous donne une certaine liberté sur l\'implémentation de la classe. Un feedback vert sur INGInious ne veut donc pas dire que tout est parfaitement correct." > feedback.out')
-    	system('sed -e \'s/^/\\t/\' < feedback.out > feedback2.out')
-    	output2 = subprocess.check_output("cat feed1 feedback2.out", shell = True)
+        system('sed -e \'s/^/\\t/\' < feedback.out > feedback2.out')
+        output2 = subprocess.check_output("cat feed1 feedback2.out", shell = True)
         system("feedback -i q1 --result success --feedback \"" + output2 + "\"")
-    	system("feedback --result success --feedback \" \" ")
+        system("feedback --result success --feedback \" \" ")

--- a/m09real/run
+++ b/m09real/run
@@ -1,4 +1,4 @@
-#!/usr/bin/python2
+#!/usr/bin/python3
 # -*- coding: utf-8 -*-
 
 # A modifier : 
@@ -42,26 +42,25 @@ unzipOutput = inginiousUtils.extract_zip_content('basicSubmission.zip', expected
 if (unzipOutput):
     output += unzipOutput
     output += "\n**Archive Content: 0/1**"
-    system('archive -a build.manifest')
     system('feedback --result failed --feedback "' + output + '"')
     exit(0)
 else:
     system('sh custom.sh')
     try:
-    	subprocess.check_output("javac -cp .:/usr/share/java/junit.jar:/usr/share/java/hamcrest-core.jar student/*.java", stderr = subprocess.STDOUT, shell = True)
-    	output += "Your archive has the correct content.\n"
-    	output += "\n**Archive content: 1/1**"
-    	system('feedback --result success --feedback "' + output + '"')
-    except subprocess.CalledProcessError, e:
+        subprocess.check_output("javac -cp .:/usr/share/java/junit.jar:/usr/share/java/hamcrest-core.jar student/*.java", stderr = subprocess.STDOUT, shell = True)
+        output += "Your archive has the correct content.\n"
+        output += "\n**Archive content: 1/1**"
+        system('feedback --result success --feedback "' + output + '"')
+    except subprocess.CalledProcessError as e:
         output += "There are some compilation errors with your program :\n::\n\n"
         sp = subprocess.Popen(["sed", "-e", "s/^/\\t/"], stdin=subprocess.PIPE, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
-    	output += sp.communicate(e.output)[0]
-    	sp = subprocess.Popen(["feedback", "--result", "failed", "--feedback", output])
-    	exit(1)
+        output += sp.communicate(e.output)[0]
+        sp = subprocess.Popen(["feedback", "--result", "failed", "--feedback", output])
+        exit(1)
     # On lance le feedback complet
     system('sh run.sh')
     if (os.stat("feedback.out").st_size != 0):
-    	output += "\n\n.. hidden-until:: " + deadline + "\n\n"
+        output += "\n\n.. hidden-until:: " + deadline + "\n\n"
         feed1 = open('feed1', 'w+')
         feed1.write(output)
         feedbackout = open('feedback.out', 'r')
@@ -86,9 +85,9 @@ else:
         proc.wait()
     else:
         output += "\n\n.. hidden-until:: \"" + deadline + "\"\n\n"
-    	system('echo "' + output + '" > feed1')
+        system('echo "' + output + '" > feed1')
         system('echo "Bravo, les tests se sont bien passés ! Faites cependant attention, les tests ne sont pas tout à fait complets étant donné que l\'on vous donne une certaine liberté sur l\'implémentation de la classe. Un feedback vert sur INGInious ne veut donc pas dire que tout est parfaitement correct." > feedback.out')
-    	system('sed -e \'s/^/\\t/\' < feedback.out > feedback2.out')
-    	output2 = subprocess.check_output("cat feed1 feedback2.out", shell = True)
+        system('sed -e \'s/^/\\t/\' < feedback.out > feedback2.out')
+        output2 = subprocess.check_output("cat feed1 feedback2.out", shell = True)
         system("feedback -i q1 --result success --feedback \"" + output2 + "\"")
-    	system("feedback --result success --feedback \" \" ")
+        system("feedback --result success --feedback \" \" ")

--- a/m10real/run
+++ b/m10real/run
@@ -1,4 +1,4 @@
-#!/usr/bin/python2
+#!/usr/bin/python3
 
 # A modifier : 
 # La liste expectedFiles, mettre les fichiers attendus dans l'archive zip.
@@ -29,23 +29,20 @@ unzipOutput = inginiousUtils.extract_zip_content('basicSubmission.zip', expected
 if (unzipOutput):
     output += unzipOutput
     output += "\n**Archive Content: 0/1**"
-    system('archive -a build.manifest')
     system('feedback --result failed --feedback "' + output + '"')
     exit(0)
 else:
     system('sh custom.sh')
     outjavac = ""
     try:
-    	subprocess.check_output("javac student/*.java", stderr = subprocess.STDOUT, shell = True)
-    	output += "Your archive has the correct content.\n"
-    	output += "\n**Archive content: 1/1**"
-    	system('feedback --result success --feedback "' + output + '"')
-    except subprocess.CalledProcessError, e:
+        subprocess.check_output("javac student/*.java", stderr = subprocess.STDOUT, shell = True)
+        output += "Your archive has the correct content.\n"
+        output += "\n**Archive content: 1/1**"
+        system('feedback --result success --feedback "' + output + '"')
+    except subprocess.CalledProcessError as e:
         output += "There are some compilation errors with your program :\n::\n\n"
         system("echo \""+e.output+"\" > outjavac.log")
-    	output += subprocess.check_output("sed -e \'s/^/\\t/\' < outjavac.log", shell = True)
-    	system('feedback --result failed --feedback "' + output + '"')
-     
+        output += subprocess.check_output("sed -e \'s/^/\\t/\' < outjavac.log", shell = True)
+        system('feedback --result failed --feedback "' + output + '"')
     
     exit(0)
-

--- a/m11real/run
+++ b/m11real/run
@@ -1,4 +1,4 @@
-#!/usr/bin/python2
+#!/usr/bin/python3
 # -*- coding: utf-8 -*-
 
 # A modifier : 
@@ -41,26 +41,25 @@ unzipOutput = inginiousUtils.extract_zip_content('basicSubmission.zip', expected
 if (unzipOutput):
     output += unzipOutput
     output += "\n**Archive Content: 0/1**"
-    system('archive -a build.manifest')
     system('feedback --result failed --feedback "' + output + '"')
     exit(0)
 else:
     system('sh custom.sh')
     try:
-    	subprocess.check_output("javac -cp .:/usr/share/java/junit.jar:/usr/share/java/hamcrest-core.jar student/*.java", stderr = subprocess.STDOUT, shell = True)
-    	output += "Your archive has the correct content.\n"
-    	output += "\n**Archive content: 1/1**"
-    	system('feedback --result success --feedback "' + output + '"')
-    except subprocess.CalledProcessError, e:
+        subprocess.check_output("javac -cp .:/usr/share/java/junit.jar:/usr/share/java/hamcrest-core.jar student/*.java", stderr = subprocess.STDOUT, shell = True)
+        output += "Your archive has the correct content.\n"
+        output += "\n**Archive content: 1/1**"
+        system('feedback --result success --feedback "' + output + '"')
+    except subprocess.CalledProcessError as e:
         output += "There are some compilation errors with your program :\n::\n\n"
         sp = subprocess.Popen(["sed", "-e", "s/^/\\t/"], stdin=subprocess.PIPE, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
-    	output += sp.communicate(e.output)[0]
-    	sp = subprocess.Popen(["feedback", "--result", "failed", "--feedback", output])
-    	exit(1)
+        output += sp.communicate(e.output)[0]
+        sp = subprocess.Popen(["feedback", "--result", "failed", "--feedback", output])
+        exit(1)
     # On lance le feedback complet
     system('sh run.sh')
     if (os.stat("feedback.out").st_size != 0):
-    	output += "\n\n.. hidden-until:: " + deadline + "\n\n"
+        output += "\n\n.. hidden-until:: " + deadline + "\n\n"
         feed1 = open('feed1', 'w+')
         feed1.write(output)
         feedbackout = open('feedback.out', 'r')
@@ -85,9 +84,9 @@ else:
         proc.wait()
     else:
         output += "\n\n.. hidden-until:: \"" + deadline + "\"\n\n"
-    	system('echo "' + output + '" > feed1')
+        system('echo "' + output + '" > feed1')
         system('echo "Bravo, les tests se sont bien passés ! Faites cependant attention, les tests ne sont pas tout à fait complets étant donné que l\'on vous donne une certaine liberté sur l\'implémentation de la classe. Un feedback vert sur INGInious ne veut donc pas dire que tout est parfaitement correct." > feedback.out')
-    	system('sed -e \'s/^/\\t/\' < feedback.out > feedback2.out')
-    	output2 = subprocess.check_output("cat feed1 feedback2.out", shell = True)
+        system('sed -e \'s/^/\\t/\' < feedback.out > feedback2.out')
+        output2 = subprocess.check_output("cat feed1 feedback2.out", shell = True)
         system("feedback -i q1 --result success --feedback \"" + output2 + "\"")
-    	system("feedback --result success --feedback \" \" ")
+        system("feedback --result success --feedback \" \" ")


### PR DESCRIPTION
And fix some indentation issues too.

This will ensure feedback is always an utf-8 string and not a mixed encoding one.